### PR TITLE
Fix build in Ubuntu 14.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ ADD_DEFINITIONS(-Wall -Wno-return-type -std=c++11 ${OPT_FLAGS} -g -DNDEBUG -DDAR
 IF(DARNER_DB)
     ADD_DEFINITIONS(-D${DARNER_DB})
     IF(DARNER_DB STREQUAL "ROCKSDB")
-        SET(DB_LIBRARIES rocksdb.a snappy.a)
+        SET(DB_LIBRARIES rocksdb.a snappy.a libz.a libbz2.a)
     ENDIF(DARNER_DB STREQUAL "ROCKSDB")
 ENDIF(DARNER_DB)
 


### PR DESCRIPTION
This change fixes the following linking error in Ubuntu 14.04:
```
//usr/local/lib/librocksdb.a(format.o): In function `Zlib_Uncompress':
/home/make/rocksdb/./util/compression.h:224: undefined reference to `inflateInit2_'
/home/make/rocksdb/./util/compression.h:240: undefined reference to `inflate'
/home/make/rocksdb/./util/compression.h:274: undefined reference to `inflateEnd'
//usr/local/lib/librocksdb.a(format.o): In function `BZip2_Uncompress':
/home/make/rocksdb/./util/compression.h:372: undefined reference to `BZ2_bzDecompressInit'
/home/make/rocksdb/./util/compression.h:387: undefined reference to `BZ2_bzDecompress'
/home/make/rocksdb/./util/compression.h:419: undefined reference to `BZ2_bzDecompressEnd'
//usr/local/lib/librocksdb.a(format.o): In function `Zlib_Uncompress':
/home/make/rocksdb/./util/compression.h:266: undefined reference to `inflateEnd'
//usr/local/lib/librocksdb.a(format.o): In function `BZip2_Uncompress':
/home/make/rocksdb/./util/compression.h:411: undefined reference to `BZ2_bzDecompressEnd'
//usr/local/lib/librocksdb.a(block_based_table_builder.o): In function `BZip2_Compress':
/home/make/rocksdb/./util/compression.h:310: undefined reference to `BZ2_bzCompressInit'
/home/make/rocksdb/./util/compression.h:324: undefined reference to `BZ2_bzCompress'
/home/make/rocksdb/./util/compression.h:340: undefined reference to `BZ2_bzCompressEnd'
//usr/local/lib/librocksdb.a(block_based_table_builder.o): In function `CompressBlock':
/home/make/rocksdb/./util/compression.h:334: undefined reference to `BZ2_bzCompressEnd'
//usr/local/lib/librocksdb.a(block_based_table_builder.o): In function `Zlib_Compress':
/home/make/rocksdb/./util/compression.h:155: undefined reference to `deflateInit2_'
/home/make/rocksdb/./util/compression.h:171: undefined reference to `deflate'
/home/make/rocksdb/./util/compression.h:188: undefined reference to `deflateEnd'
//usr/local/lib/librocksdb.a(block_based_table_builder.o): In function `CompressBlock':
/home/make/rocksdb/./util/compression.h:182: undefined reference to `deflateEnd'
collect2: error: ld returned 1 exit status
make[2]: *** [darner] Error 1
make[1]: *** [CMakeFiles/darner.dir/all] Error 2
make: *** [all] Error 2
```